### PR TITLE
gitignore: Ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .go
+
+# Ignore build artifacts
+*.so
+*.h


### PR DESCRIPTION
This change to gitignore ensures that artifacts created as a result of
the Makefile are ignored by source control.