### PR TITLE
Log the username which was authenticated, not the principal

### DIFF
--- a/pam_ussh.go
+++ b/pam_ussh.go
@@ -179,14 +179,14 @@ func authenticate(w io.Writer, uid int, username, ca string, principals map[stri
 		}
 
 		if len(principals) == 0 {
-			pamLog("Authentication succeeded for %s, cert %d", cert.ValidPrincipals[0], cert.Serial)
+			pamLog("Authentication succeeded for %s, cert %d", username, cert.Serial)
 			return AuthSuccess
 		}
 
 		for _, p := range cert.ValidPrincipals {
 			if _, ok := principals[p]; ok {
 				pamLog("Authentication succeded for %s. Matched principal %s, cert %d",
-					cert.ValidPrincipals[0], p, cert.Serial)
+					username, p, cert.Serial)
 				return AuthSuccess
 			}
 		}


### PR DESCRIPTION
In case of multiple principals in a certificate, cert.ValidPrincipals[0] will create  a log with first principal name which has no relation with the authentication. It creates misleading logs. It assumes first principal will always be the username, which might not be the case.

Instead, the username should be logged explicitly that was authenticated.