### PR TITLE
Verify the certificate is signed by the correct root CA.

### DIFF
--- a/pam_ussh.go
+++ b/pam_ussh.go
@@ -159,6 +159,11 @@ func authenticate(w io.Writer, uid int, username, ca string, principals map[stri
 			continue
 		}
 
+		if !c.IsUserAuthority(cert.SignatureKey) {
+			pamLog("certificate signed by unrecognized authority")
+			continue
+		}
+
 		// for the ssh agent to sign some data validating that they do in fact
 		// have the private key
 		randBytes := make([]byte, 32)


### PR DESCRIPTION
Fixes bug reported by penguinsaretasty.

If pam-ussh is presented a certificate signed by another authority for the current user, pam-ussh will accept the forgery and return a successful authentication.