### PR TITLE
Conditionally skip username check within certificate principals

### DIFF
--- a/pam_ussh.go
+++ b/pam_ussh.go
@@ -155,7 +155,16 @@ func authenticate(w io.Writer, uid int, username, ca string, principals map[stri
 			continue
 		}
 
-		if err := c.CheckCert(username, cert); err != nil {
+		// If a manual set of principals is provided, don't require
+		// the username to be in the certificate's principals
+		// Principals are verified at the end of this function
+		testedPrincipal := username
+		if len(principals) > 0 && len(cert.ValidPrincipals) > 0 {
+			testedPrincipal = cert.ValidPrincipals[0]
+		}
+
+		if err := c.CheckCert(testedPrincipal, cert); err != nil {
+			pamLog("Error validating cert: %v\n", err)
 			continue
 		}
 


### PR DESCRIPTION
This PR removes the requirement that a username must appear within a certificate's list of principals so long as an explicit set of valid principals is defined. This change was made so that the call to `c.CheckCert` on line 166 will verify the certificate, but explicitly exclude checking principals because pam-ussh verifies principals later in the code.

This change is related to #15.