### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: auto
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install required packages
+      run: sudo apt-get install -y libpam0g-dev
+      
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build & Test
+      run: make


### PR DESCRIPTION
Add a simple Github actions workflow to prove and demonstrate how to  build this module.
This could be the base for automated releases, for now it only runs the make command. 

Notable things for running with modern Go versions: 

`GO111MODULE=auto` is required (see: https://go.dev/blog/go116-module-changes)

----

* Add CI workflow

Add basic CI workflow to test and build

* Add libpam0g-dev

Add required package libpam0g-dev to CI